### PR TITLE
Remove pull_request trigger from develop workflow

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -4,9 +4,7 @@ on:
   push:
     branches:
       - develop
-  pull_request:
-    branches:
-      - develop
+
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:


### PR DESCRIPTION
This change eliminates the pull_request trigger from the GitHub Actions workflow for the develop branch. It streamlines the workflow configuration by only keeping the push trigger active.

Relates-to: SDK-81