### PR TITLE
Add task to delete existing artifact from Nexus repo

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,3 +19,4 @@ patchEgkAndroid=2
 buildNumber=0
 #Project settings for GitHub packages
 contextUrl=https://nexus.link4.health/repository
+apiContextUrl=https://nexus.link4.health

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -60,5 +60,5 @@ dependencyResolutionManagement {
         }
     }
 }
-rootProject.name = "link4health-egk-library"
+rootProject.name = "link4health-egk"
 include(":egk")


### PR DESCRIPTION
Introduced a Gradle task to check and delete an existing artifact in the Nexus repository before publishing a new one. This change ensures that the repository is clean and the latest version is available without conflicts. Additionally, updated the artifact ID format and the root project name for consistency.

Relates-to: SDK-81