### PR TITLE
Add Dokka artifacts to build configuration

### DIFF
--- a/egk/build.gradle.kts
+++ b/egk/build.gradle.kts
@@ -262,6 +262,11 @@ publishing {
             artifact("${layout.buildDirectory.get()}/outputs/aar/$artifactFileName") {
                 extension = "aar"
             }
+
+            // Artefakte für JavaDoc und HTML-Dokumentation
+            artifact(tasks.named("dokkaJavadocJar"))
+            artifact(tasks.named("dokkaHtmlJar"))
+
             pom {
                 name.set("Link4Health eGK Library")
                 description.set("A library to use the egk for CardLink.")


### PR DESCRIPTION
This commit updates the build script to include Dokka-generated Javadoc and HTML artifacts. These additions enhance the documentation process by ensuring Javadoc and HTML documentation are available as build artifacts.

Relates-to: SDK-81