### PR TITLE
Add Git hash classifier to AAR artifacts

### DIFF
--- a/egk/build.gradle.kts
+++ b/egk/build.gradle.kts
@@ -263,6 +263,7 @@ publishing {
 
             artifact("${layout.buildDirectory.get()}/outputs/aar/$artifactFileName") {
                 extension = "aar"
+                classifier = gitHash
             }
 
             // Artefakte für JavaDoc und HTML-Dokumentation


### PR DESCRIPTION
This change enhances the artifact naming by adding the Git hash as a classifier. It ensures that each generated AAR artifact is uniquely identified, aiding in version tracking and debugging.