### PR TITLE
Remove classifier from artifact configuration

### DIFF
--- a/egk/build.gradle.kts
+++ b/egk/build.gradle.kts
@@ -263,7 +263,6 @@ publishing {
 
             artifact("${layout.buildDirectory.get()}/outputs/aar/$artifactFileName") {
                 extension = "aar"
-                classifier = gitHash
             }
 
             // Artefakte für JavaDoc und HTML-Dokumentation


### PR DESCRIPTION
The classifier property was removed from the artifact declaration in the build.gradle.kts file. This simplifies the artifact naming and ensures consistency in the build output paths.